### PR TITLE
tests: ChannelTest: check deleted channel is not in database

### DIFF
--- a/src/tests/Feature/API/v1/Channel/ChannelTest.php
+++ b/src/tests/Feature/API/v1/Channel/ChannelTest.php
@@ -140,6 +140,9 @@ class ChannelTest extends TestCase
             'id' => $channel->id
         ]);
 
-        $response->assertStatus(Response::HTTP_OK);
+	 $response->assertStatus(Response::HTTP_OK);
+
+	// check the deleted channel is not in database
+	$this->assertTrue(Channel::where('id' , $channel->id)->count() == 0);
     }
 }


### PR DESCRIPTION
check the deleted channel is not in database after call channel delete api in channel test